### PR TITLE
Execute write next callback

### DIFF
--- a/cmd.js
+++ b/cmd.js
@@ -73,7 +73,9 @@ fs.mkdirSync(argv.datadir, { recursive: true })
   })
   var count = 0
   var ingest = through.obj(write, end)
-  pump(process.stdin, fmt, bstream, ingest)
+  pump(process.stdin, fmt, bstream, ingest, function done (error) {
+    if (error) throw error
+  })
   function write(batch, enc, next) {
     count += batch.length
     db.batch(batch).then(() => {

--- a/cmd.js
+++ b/cmd.js
@@ -79,7 +79,7 @@ fs.mkdirSync(argv.datadir, { recursive: true })
     db.batch(batch).then(() => {
       if (count > syncSize) {
         count = 0
-        db.sync().then(() => next).catch(next)
+        db.sync().then(next).catch(next)
       } else next()
     }).catch(next)
   }


### PR DESCRIPTION
Without calling the `next` function the command silently fails. Also added a callback to pump that throws an error if one occurs in the stream pipeline.